### PR TITLE
docs: fix script paths and add newconfdesign info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Dette repo samler små værktøjer, som jeg bygger under min IT-supporter-uddann
 
 ## Værktøjer
 
+Filerne `getconf.py`, `ipbin.py` og `newconfdesign.py` ligger i undermappen `intermediate/`.
+
 ### `Setconf.py`
 Uploader konfiguration til et Cisco IOS-device via NAPALM med enten *merge* eller *replace*-mode.
 
@@ -13,26 +15,34 @@ Eksempel:
 python Setconf.py --ssh 192.0.2.1 -u brugernavn -f config.txt --mode merge
 ```
 
-### `getconf.py`
+### `intermediate/getconf.py`
 Henter startup- og evt. running-config fra et device via SSH eller seriel COM og gemmer til fil.
 
 Eksempel via SSH:
 ```bash
-python getconf.py --ssh 192.0.2.1 -u brugernavn -f backup.txt
+python intermediate/getconf.py --ssh 192.0.2.1 -u brugernavn -f backup.txt
 ```
 
 Eksempel via COM:
 ```bash
-python getconf.py --com COM3 -f backup.txt
+python intermediate/getconf.py --com COM3 -f backup.txt
 ```
 
-### `ipbin.py`
+### `intermediate/ipbin.py`
 Konverterer tal mellem decimal, hex og binær – og kan også tolke IPv4-adresser.
 
 Eksempel:
 ```bash
-python ipbin.py 192.168.0.1
-python ipbin.py 0xff
+python intermediate/ipbin.py 192.168.0.1
+python intermediate/ipbin.py 0xff
+```
+
+### `intermediate/newconfdesign.py`
+Tekstbaseret brugerflade (TUI) til at generere Cisco-switchkonfigurationer ud fra VLAN-profiler.  Kræver `curses` (på Windows: `pip install windows-curses`).
+
+Eksempel:
+```bash
+python intermediate/newconfdesign.py
 ```
 
 ## Tak


### PR DESCRIPTION
## Summary
- clarify that getconf.py, ipbin.py, and newconfdesign.py live under `intermediate/`
- correct example commands to use `intermediate/` paths
- document `newconfdesign.py` with description and usage

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c52b85b4a4832ba2a34922bb4a2721