### PR TITLE
Tidy up repo and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,89 @@
-# confdesign
+# netops-toolkit
 
-## Oversigt
-Dette repo samler små værktøjer, som jeg bygger under min IT-supporter-uddannelse.
+Et lille bibliotek af netværksværktøjer, som er blevet til under min IT-supporter-uddannelse.
+Skripterne hjælper med daglig drift af Cisco-udstyr, subnet-beregninger og et par studiehjælpere.
 
-## Værktøjer
+## Installation
 
-Filerne `getconf.py`, `ipbin.py` og `newconfdesign.py` ligger i undermappen `intermediate/`.
+Alle værktøjer kører på Python 3.10+.
+Opret gerne et virtuelt miljø og installer afhængighederne fra `requirements.txt`:
 
-### `Setconf.py`
-Uploader konfiguration til et Cisco IOS-device via NAPALM med enten *merge* eller *replace*-mode.
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
 
-Eksempel:
+> `windows-curses` er kun nødvendigt på Windows, hvis `newconfdesign.py` skal bruges.
+
+## Hurtigt overblik
+
+| Kategori | Fil | Kort beskrivelse |
+| --- | --- | --- |
+| Device-automation | `Setconf.py` | Uploader konfiguration til Cisco IOS via NAPALM i merge/replace-mode. |
+| Device-backup | `intermediate/getconf.py` | Henter startup- (og evt. running-) config via SSH eller seriel COM. |
+| Config-design | `intermediate/newconfdesign.py` | Curses-baseret TUI til at bygge switch-profiler og generere konfiguration. |
+| Subnetting | `subnetting/ipbin.py` | Konverter tal mellem decimal/hex/binær og tolker IPv4-adresser. |
+| Subnetting | `subnetting/subnetcalc.py` | Beregner subnets, VLSM og eksport til CSV. |
+
+## Værktøjerne i detaljer
+
+### Setconf.py
+Uploader en lokal konfigurationsfil til et Cisco IOS-device med NAPALM.
+Viser et diff-panel via Rich før commit og kan automatisk rulle tilbage ved fejl.
+
 ```bash
 python Setconf.py --ssh 192.0.2.1 -u brugernavn -f config.txt --mode merge
 ```
 
-### `intermediate/getconf.py`
-Henter startup- og evt. running-config fra et device via SSH eller seriel COM og gemmer til fil.
+Flag:
+- `--mode {merge,replace}` vælger merge- eller replace-mode.
+- `--yes` skipper bekræftelses-prompt.
+- `--rollback` udfører `rollback()` hvis commit fejler.
 
-Eksempel via SSH:
+### intermediate/getconf.py
+Tager backup af konfigurationen enten over SSH eller via seriel COM.
+
+a) SSH (NAPALM):
 ```bash
-python intermediate/getconf.py --ssh 192.0.2.1 -u brugernavn -f backup.txt
+python intermediate/getconf.py --ssh 192.0.2.1 -u brugernavn -f backups/router1.txt -c
 ```
+`-c` gemmer også running-config.
 
-Eksempel via COM:
+b) Seriel COM:
 ```bash
-python intermediate/getconf.py --com COM3 -f backup.txt
+python intermediate/getconf.py --com COM3 -f backups/router1.txt --baud 9600 -c
 ```
+Programmet spørger efter passwords, hvis de ikke angives med flag.
 
-### `intermediate/ipbin.py`
-Konverterer tal mellem decimal, hex og binær – og kan også tolke IPv4-adresser.
+### intermediate/newconfdesign.py
+TUI der guider dig gennem oprettelse af VLAN-profiler og genererer et konfigurationsudkast.
+Profiler gemmes i `profiles.json`, så de kan genbruges.
 
-Eksempel:
-```bash
-python intermediate/ipbin.py 192.168.0.1
-python intermediate/ipbin.py 0xff
-```
-
-### `intermediate/newconfdesign.py`
-Tekstbaseret brugerflade (TUI) til at generere Cisco-switchkonfigurationer ud fra VLAN-profiler.  Kræver `curses` (på Windows: `pip install windows-curses`).
-
-Eksempel:
 ```bash
 python intermediate/newconfdesign.py
 ```
 
-### `subnet.py`
-Beregn netværks- og broadcast-adresser samt antal brugbare hosts ud fra en
-adresse og enten prefixlængde eller ønsket antal værter.
+### subnetting/ipbin.py
+Smart base-konverter: forstår decimal, hex, binær og dotted IPv4. Viser både flade tal og oktetter.
 
-Eksempel:
 ```bash
-python subnet.py 192.168.1.5 --prefix 24
-python subnet.py 10.0.0.0 --hosts 50
+python subnetting/ipbin.py 192.168.0.1
+python subnetting/ipbin.py 0xff
+python subnetting/ipbin.py 11000000101010000000000000000001
 ```
 
-## Tak
-Jeg har fået hjælp af min gode ven ChatGPT.
+### subnetting/subnetcalc.py
+Subnet-lommeregner der kan arbejde med både faste prefix og VLSM.
+
+```bash
+python subnetting/subnetcalc.py --base 192.168.100.0/24 --target-prefix 26
+python subnetting/subnetcalc.py --base 10.0.0.0/24 --min-hosts 50
+python subnetting/subnetcalc.py --base 192.168.10.0/24 --vlsm --csv subnets.csv
+```
+
+## Fremtidige tanker
+
+Repoet har tidligere heddet `confdesign`.
+Gamle placeholders som `ansible-confs/` og `todo` er fjernet for at holde fokus på de aktive værktøjer.
+Hvis repoet omdøbes til `netops-toolkit` på GitHub matcher navnet nu projektets bredere fokus.

--- a/ansible-confs/readme-todo.MD
+++ b/ansible-confs/readme-todo.MD
@@ -1,2 +1,0 @@
-#make a nice tempate for a ansible.
-##and make a dir for the playbooks that i maigt want to keep

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+beautifulsoup4>=4.12
+lxml
+napalm
+pyserial
+rich

--- a/todo
+++ b/todo
@@ -1,2 +1,0 @@
-#this will be the todo for the repo. 
-##files that need fixing or new tool ideas will be put here. to do later, then i have more freetime


### PR DESCRIPTION
## Summary
- rename the project in the docs to **netops-toolkit** and expand the README with installation notes, tool overview and usage examples
- remove abandoned placeholder files (`ansible-confs/`, `todo`) so only active utilities remain
- add a `requirements.txt` covering the shared Python dependencies
- trim the README per feedback by omitting the ANSWERPAR helper and describing the subnet tool as en lommeregner

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cc6ba5d26c832bb6b855f25ff48cf8